### PR TITLE
Collapse open category when player clicks submit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ $('.questions__current--question--submit--btn').click(function() {
   // check answer
   // give feedback
   // update score
+  $(".round__point--container").slideUp();
   let playersAnswer = $(`.questions__current--question--answer--input`).val();
   game.round.getPlayerAnswer(playersAnswer);
   console.log(game.round.currentPlayer.score);


### PR DESCRIPTION
Once the player hits submit after answer the question the, whichever open category they opened closes resetting for the next player/turn.